### PR TITLE
remove extraneous stdout in node.js.hb

### DIFF
--- a/templates/node.js.hb
+++ b/templates/node.js.hb
@@ -8,10 +8,6 @@ var grunt_process = spawn(
   }
 );
 
-grunt_process.stdout.on('data', function (data) {
-  console.log(data);
-});
-
 grunt_process.stdout.setEncoding('utf8');
 grunt_process.stdout.on('data', function (data) {
   console.log(data);


### PR DESCRIPTION
It was giving me double feedback when not using a template, so I removed it as it looked like it was already happening directly below as well.